### PR TITLE
Obscure sensible values on .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_ENV=local
-APP_DEBUG=true
+APP_DEBUG=false
 APP_KEY=SomeRandomString
 APP_URL=http://localhost
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ This project is build using [Laravel](http://laravel.com/) web framework;
    $ composer install
    ```
 
+1. Copy the sample configuration file and set your environment variables
+   ```bash
+   $ cp .env.example .env
+   ```
+
 1. Generate an `APP_KEY`.
 
    ```bash


### PR DESCRIPTION
Avoids exposing sensible variables on production.

Changes in the PR:

- Change APP_DEBUG to false.

Not possible due to the Laravel version: 
- `debug_blacklist` to avoid exposing sensible variables even when debug is true. It was added in Laravel 5.5.13, and project version is Laravel 5.2
